### PR TITLE
allow custom template, add one more template

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,22 +154,61 @@ Options to pass to the Mustache template that generates your stylesheets.
 
 As of now, you have one real option, `{ functions: false }`, which will make it so the generated SCSS includes variables only, not mixins. This is handy if you are using multiple sprites in a project and don't want to duplicate the mixin definitions.
 
+#### ldCssTemplate
+Type: `String`
+Default: undefined
+
+The default results in the use of the default template for the `scss` extension of json2css.
+You can pass a path to a template that is then passed to grunt-spritesmith as the cssTemplate option. The path can be relative to the directory where you call grunt or relative to the tasks directory of grunt-spritesmith-hd.
+
+#### hdCssTemplate
+Type: `String`
+Default: path.join(__dirname, 'templates/scss-hd.template.mustache')
+
+If you don't pass this option, the scss-hd.template.mustache from grunt-spritesmith-hd is used.
+You can pass a path to a template that is then passed to grunt-spritesmith as the cssTemplate option. The path can be relative to the directory where you call grunt or relative to the tasks directory of grunt-spritesmith-hd.
+
 ## Examples
 
+### Basic:
 ```javascript
 spriteHD: {
   options: {
-    destImg: "sprites"
-    destCSS: "scss/sprites"
+    destImg: "sprites",
+    destCSS: "scss/sprites",
     imgPath: "sprites"
   }
   all {
-    src: ["images/sprite-assets/all/*"]
+    src: ["images/sprite-assets/all/*"],
     spriteName: "all"
   }
   home: {
-    src: ["images/sprite-assets/home/*"]
-    spriteName: "home"
+    src: ["images/sprite-assets/home/*"],
+    spriteName: "home",
+    cssOpts: {
+      functions: false
+    }
+  }
+}
+```
+### combined scss maps:
+This uses the template at https://github.com/benib/json2css_scss_combined_maps
+```javascript
+spriteHD: {
+  options: {
+    destImg: "sprites",
+    destCSS: "scss/sprites",
+    imgPath: "sprites",
+    hdCssTemplate: 'node_modules/json2css_scss_combined_maps/scss_combined_maps.template.mustache',
+    ldCssTemplate: 'templates/scss_combined_maps-hd.template.mustache'
+  }
+  all {
+    src: ["images/sprite-assets/all/*"],
+    spriteName: "all"
+  }
+  home: {
+    src: ["images/sprite-assets/home/*"],
+    spriteName: "home",
     cssOpts: {
       functions: false
     }

--- a/tasks/spritesmith-hd.js
+++ b/tasks/spritesmith-hd.js
@@ -28,6 +28,8 @@ module.exports = function(grunt) {
         engineOpts = options.engineOpts || {},
         imageOpts = options.imageOpts || {},
         cssOpts = options.cssOpts || {},
+        hdCssTemplate = options.hdCssTemplate || undefined,
+        ldCssTemplate = options.ldCssTemplate || path.join(__dirname, 'templates/scss-hd.template.mustache'),
         algorithmOpts = options.algorithmOpts || {},
 
         // Other
@@ -37,6 +39,22 @@ module.exports = function(grunt) {
         hdPrefix = options.hdPrefix || 'hd',
         ldPrefix = options.ldPrefix || 'ld',
         imgType = 'png';
+
+    //test the optionally passed template paths to abort as early as possible
+    if (hdCssTemplate !== undefined && !grunt.file.exists(hdCssTemplate)) {
+      if (grunt.file.exists(path.join(__dirname, hdCssTemplate))) {
+        hdCssTemplate = path.join(__dirname, hdCssTemplate);
+      } else {
+        grunt.fail.fatal('the template passed as hdCssTemplate at "' + hdCssTemplate + '" could not be found');
+      }
+    }
+    if (!grunt.file.exists(ldCssTemplate)) {
+      if (grunt.file.exists(path.join(__dirname, ldCssTemplate))) {
+        ldCssTemplate = path.join(__dirname, ldCssTemplate);
+      } else {
+        grunt.fail.fatal('the template passed as ldCssTemplate at "' + ldCssTemplate + '" could not be found');
+      }
+    }
 
     // Derivations from the settings.
     var srcFiles = grunt.file.expand(src),
@@ -194,10 +212,14 @@ module.exports = function(grunt) {
           'imgPath': hdImgPath,
           'padding': padding * 2,
           'cssOpts': {
-            'functions': false
+            'functions': false,
+            'spriteName': spriteName
           }
         }
       };
+      if (hdCssTemplate !== undefined) {
+        grunt.util._.extend(hdSpritesmithParams.hd, { 'cssTemplate': hdCssTemplate });
+      }
       grunt.util._.extend(hdSpritesmithParams.hd, spritesmithParams);
 
       var ldSpritesmithParams = {
@@ -207,12 +229,14 @@ module.exports = function(grunt) {
           'destCSS': ldDestCSS,
           'imgPath': ldImgPath,
           'padding': padding,
-          'cssTemplate': path.join(__dirname, 'templates/scss-hd.template.mustache')
+          'cssTemplate': ldCssTemplate
         }
       };
       ldSpritesmithParams.ld.cssOpts = grunt.util._.extend(cssOpts, {
         'hdPath': hdStyleName,
-        'hdPrefix': hdPrefix
+        'hdPrefix': hdPrefix,
+        'functions': true,
+        'spriteName': spriteName
       });
       grunt.util._.extend(ldSpritesmithParams.ld, spritesmithParams);
 

--- a/tasks/templates/scss_combined_maps-hd.template.mustache
+++ b/tasks/templates/scss_combined_maps-hd.template.mustache
@@ -1,0 +1,72 @@
+{
+  // Default options
+  'functions': true,
+  'spriteName': 'sprites'
+}
+
+${{options.spriteName}}-ld: (
+  {{#items}}
+  {{name}}: (
+    x: {{px.x}},
+    y: {{px.y}},
+    offset_x: {{px.offset_x}},
+    offset_y: {{px.offset_y}},
+    width: {{px.width}},
+    height: {{px.height}},
+    total_width: {{px.total_width}},
+    total_height: {{px.total_height}},
+    image: '{{{escaped_image}}}',
+    hd-name: {{options.hdPrefix}}-{{name}}
+  ),
+  {{/items}}
+);
+
+{{#options.functions}}
+@function sprite_{{options.spriteName}}-ld($sprite, $attribute) {
+  @return map-get(map-get(${{options.spriteName}}-ld, $sprite), $attribute)
+}
+
+@function sprite_{{options.spriteName}}-hd($sprite, $attribute) {
+  @return map-get(map-get(${{options.spriteName}}, $sprite), $attribute)
+}
+
+@mixin sprite_{{options.spriteName}}-width($sprite) {
+  width: sprite_{{options.spriteName}}-ld($sprite, 'width');
+}
+
+@mixin sprite_{{options.spriteName}}-height($sprite) {
+  height: sprite_{{options.spriteName}}-ld($sprite, 'height');
+}
+
+@mixin sprite_{{options.spriteName}}-position($sprite) {
+  background-position: sprite_{{options.spriteName}}-ld($sprite, 'offset_x') sprite_{{options.spriteName}}-ld($sprite, 'offset_y');
+}
+
+@mixin sprite_{{options.spriteName}}-image-hd($sprite) {
+  background-image: url(sprite_{{options.spriteName}}-hd($sprite, 'image'));
+}
+
+@mixin sprite_{{options.spriteName}}-image($sprite) {
+  background-image: url(sprite_{{options.spriteName}}-ld($sprite, 'image'));
+}
+
+@mixin sprite_{{options.spriteName}}-hd($sprite) {
+  $sprite-total-width: sprite_{{options.spriteName}}-ld($sprite, 'total_width');
+  $sprite-total-height: sprite_{{options.spriteName}}-ld($sprite, 'total_height');
+  @media (-o-min-device-pixel-ratio: 5/4),
+         (-webkit-min-device-pixel-ratio: 1.25),
+         (min-resolution: 120dpi) {
+    $hd-name: sprite_{{options.spriteName}}-ld($sprite, 'hd-name');
+    @include sprite_{{options.spriteName}}-image-hd($hd-name);
+    background-size: $sprite-total-width $sprite-total-height;
+  }
+}
+
+@mixin sprite_{{options.spriteName}}($sprite) {
+  @include sprite_{{options.spriteName}}-image($sprite);
+  @include sprite_{{options.spriteName}}-position($sprite);
+  @include sprite_{{options.spriteName}}-width($sprite);
+  @include sprite_{{options.spriteName}}-height($sprite);
+  @include sprite_{{options.spriteName}}-hd($sprite);
+}
+{{/options.functions}}


### PR DESCRIPTION
This is a follow up to davidtheclark/grunt-spritesmith-hd#9
It allowes for custom templates to be used which gives more flexibility.

It adds one template called scss_combined_maps-hd that can be used together with the template from https://github.com/benib/json2css_scss_combined_maps to get a result like:

```
$icons-ld: (
  icon: (
    x: 62px,
    y: 0px,
    offset_x: -62px,
    offset_y: 0px,
    width: 102px,
    height: 65px,
    total_width: 347px,
    total_height: 174px,
    image: '/images/ld-icons.png',
    hd-name: hd-icon
  ),
  ...
);
```

This allowes for the icon name to be a string instead of a variable, which makes it compatible with the compass spriting system and allowes for a painless transition to grunt-spritesmith. Another possible advantage is, that strings can be generated while variable names can not in sass. For a longer discussion about this, see twolfson/json2css#27.
